### PR TITLE
Pytest

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.1.1 (current version)
+-----------------------
+
+* Various bug fixes (see :issue:`2`)
+
+
 0.1.0 (2017-07-24)
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,8 +58,8 @@ extensions = [
     'sphinx.ext.intersphinx']
 
 extlinks = {
-    'issue': ('https://github.com/ClimateImpactLab/DataFS/issues/%s', 'GH #'),
-    'pull': ('https://github.com/ClimateImpactLab/DataFS/pull/%s', 'PR #')}
+    'issue': ('https://github.com/ClimateImpactLab/climate_toolbox/issues/%s', 'GH #'),
+    'pull': ('https://github.com/ClimateImpactLab/climate_toolbox/pull/%s', 'PR #')}
 
 napoleon_numpy_docstring = True
 


### PR DESCRIPTION
 - [x] closes #2 
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 climate_toolbox tests docs``
 - [x] entry in HISTORY.rst

Lots of updates:
* Adds pytest.ini file
* suppresses nonlocal uri warning in docs build
* makes tests run on smaller data sets
* add pytest-cov to produce coverage report
* fix bug in conf.py which pointed `:issue:` and `:pull:` references to DataFS
* flake8