### PR TITLE
Bug fixes and cleanup to pass flake8 in CI

### DIFF
--- a/climate_toolbox/__init__.py
+++ b/climate_toolbox/__init__.py
@@ -3,5 +3,5 @@
 """Top-level package for climate_toolbox."""
 
 __author__ = """Justin Simcock"""
-__email__ = 'jsimcock@rhg.com'
-__version__ = '0.1.5'
+__email__ = "jsimcock@rhg.com"
+__version__ = "0.1.5"

--- a/climate_toolbox/climate_toolbox.py
+++ b/climate_toolbox/climate_toolbox.py
@@ -1,4 +1,3 @@
 """
 This file describes the process for computing weighted climate data
 """
-

--- a/climate_toolbox/geo/distance.py
+++ b/climate_toolbox/geo/distance.py
@@ -1,12 +1,14 @@
 import numpy as np
+
 #             model             major (km)   minor (km)     flattening
-ELLIPSOIDS = {'WGS-84':        (6378.137,    6356.7523142,  1 / 298.257223563),
-              'GRS-80':        (6378.137,    6356.7523141,  1 / 298.257222101),
-              'Airy (1830)':   (6377.563396, 6356.256909,   1 / 299.3249646),
-              'Intl 1924':     (6378.388,    6356.911946,   1 / 297.0),
-              'Clarke (1880)': (6378.249145, 6356.51486955, 1 / 293.465),
-              'GRS-67':        (6378.1600,   6356.774719,   1 / 298.25),
-              }
+ELLIPSOIDS = {
+    "WGS-84": (6378.137, 6356.7523142, 1 / 298.257223563),
+    "GRS-80": (6378.137, 6356.7523141, 1 / 298.257222101),
+    "Airy (1830)": (6377.563396, 6356.256909, 1 / 299.3249646),
+    "Intl 1924": (6378.388, 6356.911946, 1 / 297.0),
+    "Clarke (1880)": (6378.249145, 6356.51486955, 1 / 293.465),
+    "GRS-67": (6378.1600, 6356.774719, 1 / 298.25),
+}
 
 
 EARTH_RADIUS = 6371.009
@@ -57,9 +59,12 @@ def great_circle(ax, ay, bx, by, radius=EARTH_RADIUS):
     delta_lng = lng2 - lng1
     cos_delta_lng, sin_delta_lng = np.cos(delta_lng), np.sin(delta_lng)
 
-    d = np.arctan2(np.sqrt((cos_lat2 * sin_delta_lng) ** 2 +
-                   (cos_lat1 * sin_lat2 -
-                    sin_lat1 * cos_lat2 * cos_delta_lng) ** 2),
-              sin_lat1 * sin_lat2 + cos_lat1 * cos_lat2 * cos_delta_lng)
+    d = np.arctan2(
+        np.sqrt(
+            (cos_lat2 * sin_delta_lng) ** 2
+            + (cos_lat1 * sin_lat2 - sin_lat1 * cos_lat2 * cos_delta_lng) ** 2
+        ),
+        sin_lat1 * sin_lat2 + cos_lat1 * cos_lat2 * cos_delta_lng,
+    )
 
     return radius * d

--- a/climate_toolbox/io/io.py
+++ b/climate_toolbox/io/io.py
@@ -19,12 +19,12 @@ def standardize_climate_data(ds):
     """
 
     ds = rename_coords_to_lon_and_lat(ds)
-    ds = convert_lons_split(ds, lon_name='lon')
+    ds = convert_lons_split(ds, lon_name="lon")
 
     return ds
 
 
-def load_bcsd(fp, varname, lon_name='lon', broadcast_dims=('time',)):
+def load_bcsd(fp, varname, lon_name="lon", broadcast_dims=("time",)):
     """
     Read and prepare climate data
 
@@ -52,7 +52,7 @@ def load_bcsd(fp, varname, lon_name='lon', broadcast_dims=('time',)):
     if lon_name is not None:
         lon_names = [lon_name]
 
-    if hasattr(fp, 'sel_points'):
+    if hasattr(fp, "sel_points"):
         ds = fp
 
     else:
@@ -62,10 +62,9 @@ def load_bcsd(fp, varname, lon_name='lon', broadcast_dims=('time',)):
     return standardize_climate_data(ds)
 
 
-def load_gmfd(fp, varname, lon_name='lon', broadcast_dims=('time',)):
+def load_gmfd(fp, varname, lon_name="lon", broadcast_dims=("time",)):
     pass
 
 
-def load_best(fp, varname, lon_name='lon', broadcast_dims=('time',)):
+def load_best(fp, varname, lon_name="lon", broadcast_dims=("time",)):
     pass
-

--- a/climate_toolbox/io/io.py
+++ b/climate_toolbox/io/io.py
@@ -1,6 +1,6 @@
 import xarray as xr
 
-from climate_toolbox.utils.utils import *
+from climate_toolbox.utils.utils import rename_coords_to_lon_and_lat, convert_lons_split
 
 
 def standardize_climate_data(ds):

--- a/climate_toolbox/io/io.py
+++ b/climate_toolbox/io/io.py
@@ -48,10 +48,6 @@ def load_bcsd(fp, varname, lon_name="lon", broadcast_dims=("time",)):
     xr.Dataset
          xarray dataset loaded into memory
     """
-
-    if lon_name is not None:
-        lon_names = [lon_name]
-
     if hasattr(fp, "sel_points"):
         ds = fp
 

--- a/climate_toolbox/transformations/transformations.py
+++ b/climate_toolbox/transformations/transformations.py
@@ -1,8 +1,7 @@
 import xarray as xr
 import numpy as np
 
-from climate_toolbox.utils.utils import \
-    remove_leap_days, convert_kelvin_to_celsius
+from climate_toolbox.utils.utils import remove_leap_days, convert_kelvin_to_celsius
 
 
 def snyder_edd(tasmin, tasmax, threshold):
@@ -67,9 +66,9 @@ def snyder_edd(tasmin, tasmax, threshold):
     assert not (tasmax < tasmin).any(), "values encountered where tasmin > tasmax"
 
     # compute useful quantities for use in the transformation
-    snyder_mean = ((tasmax + tasmin)/2)
-    snyder_width = ((tasmax - tasmin)/2)
-    snyder_theta = xr.ufuncs.arcsin((threshold - snyder_mean)/snyder_width)
+    snyder_mean = (tasmax + tasmin) / 2
+    snyder_width = (tasmax - tasmin) / 2
+    snyder_theta = xr.ufuncs.arcsin((threshold - snyder_mean) / snyder_width)
 
     # the trasnformation is computed using numpy arrays, taking advantage of
     # numpy's second where clause. Note that in the current dev build of
@@ -79,13 +78,17 @@ def snyder_edd(tasmin, tasmax, threshold):
         tasmin < threshold,
         xr.where(
             tasmax > threshold,
-            ((snyder_mean - threshold) * (np.pi/2 - snyder_theta)
-                + (snyder_width * np.cos(snyder_theta))) / np.pi,
-            0),
-        snyder_mean - threshold)
+            (
+                (snyder_mean - threshold) * (np.pi / 2 - snyder_theta)
+                + (snyder_width * np.cos(snyder_theta))
+            )
+            / np.pi,
+            0,
+        ),
+        snyder_mean - threshold,
+    )
 
-    res.attrs['units'] = (
-        'degreedays_{}{}'.format(threshold, tasmax.attrs['units']))
+    res.attrs["units"] = "degreedays_{}{}".format(threshold, tasmax.attrs["units"])
 
     return res
 
@@ -133,19 +136,19 @@ def snyder_gdd(tasmin, tasmax, threshold_low, threshold_high):
     # Check for unit agreement
     assert tasmin.units == tasmax.units
 
-    res = (
-        snyder_edd(tasmin, tasmax, threshold_low)
-        - snyder_edd(tasmin, tasmax, threshold_high))
+    res = snyder_edd(tasmin, tasmax, threshold_low) - snyder_edd(
+        tasmin, tasmax, threshold_high
+    )
 
-    res.attrs['units'] = (
-        'degreedays_{}-{}{}'.format(threshold_low, threshold_high, tasmax.attrs['units']))
-
+    res.attrs["units"] = "degreedays_{}-{}{}".format(
+        threshold_low, threshold_high, tasmax.attrs["units"]
+    )
 
     return res
 
 
 def validate_edd_snyder_agriculture(ds, thresholds):
-    msg_null = 'hierid dims do not match 24378'
+    msg_null = "hierid dims do not match 24378"
 
     assert ds.hierid.shape == (24378,), msg_null
 
@@ -164,15 +167,18 @@ def tas_poly(ds, power, varname):
 
     powername = ordinal(power)
 
-    description = ('''
+    description = (
+        """
             Daily average temperature (degrees C){raised}
 
             Leap years are removed before counting days (uses a 365 day
             calendar).
-            '''.format(
-                raised='' if power == 1 else (
-                    ' raised to the {powername} power'
-                    .format(powername=powername)))).strip()
+            """.format(
+            raised=""
+            if power == 1
+            else (" raised to the {powername} power".format(powername=powername))
+        )
+    ).strip()
 
     ds1 = xr.Dataset()
 
@@ -180,32 +186,29 @@ def tas_poly(ds, power, varname):
     ds = remove_leap_days(ds)
 
     # do transformation
-    ds1[varname] = (ds.tas - 273.15)**power
+    ds1[varname] = (ds.tas - 273.15) ** power
 
     # Replace datetime64[ns] 'time' with YYYYDDD int 'day'
-    if ds.dims['time'] > 365:
+    if ds.dims["time"] > 365:
         raise ValueError
 
-    ds1.coords['day'] = ds['time.year']*1000 + np.arange(1, len(ds.time)+1)
-    ds1 = ds1.swap_dims({'time': 'day'})
-    ds1 = ds1.drop('time')
+    ds1.coords["day"] = ds["time.year"] * 1000 + np.arange(1, len(ds.time) + 1)
+    ds1 = ds1.swap_dims({"time": "day"})
+    ds1 = ds1.drop("time")
 
-    ds1 = ds1.rename({'day': 'time'})
+    ds1 = ds1.rename({"day": "time"})
 
     # document variable
-    ds1[varname].attrs['units'] = (
-        'C^{}'.format(power) if power > 1 else 'C')
+    ds1[varname].attrs["units"] = "C^{}".format(power) if power > 1 else "C"
 
-    ds1[varname].attrs['long_title'] = description.splitlines()[0]
-    ds1[varname].attrs['description'] = description
-    ds1[varname].attrs['variable'] = varname
+    ds1[varname].attrs["long_title"] = description.splitlines()[0]
+    ds1[varname].attrs["description"] = description
+    ds1[varname].attrs["variable"] = varname
 
     return ds1
 
 
 def ordinal(n):
-    """ Converts numbers into ordinal strings """
+    """Converts numbers into ordinal strings"""
 
-    return (
-        "%d%s" %
-        (n, "tsnrhtdd"[(n // 10 % 10 != 1) * (n % 10 < 4) * n % 10::4]))
+    return "%d%s" % (n, "tsnrhtdd"[(n // 10 % 10 != 1) * (n % 10 < 4) * n % 10 :: 4])

--- a/climate_toolbox/utils/utils.py
+++ b/climate_toolbox/utils/utils.py
@@ -7,23 +7,23 @@ import numpy as np
 
 
 def convert_kelvin_to_celsius(df, temp_name):
-    """ Convert Kelvin to Celsius """
+    """Convert Kelvin to Celsius"""
     df_attrs = df[temp_name].attrs
     df[temp_name] = df[temp_name] - 273.15
     # update attrs & unit information
     df[temp_name].attrs.update(df_attrs)
-    df[temp_name].attrs['units'] = 'C'
-    df[temp_name].attrs['valid_min'] = -108.78788
-    df[temp_name].attrs['valid_max'] = 62.02828
+    df[temp_name].attrs["units"] = "C"
+    df[temp_name].attrs["valid_min"] = -108.78788
+    df[temp_name].attrs["valid_max"] = 62.02828
 
     return df
 
 
-def convert_lons_mono(ds, lon_name='longitude'):
-    """ Convert longitude from -180-180 to 0-360 """
+def convert_lons_mono(ds, lon_name="longitude"):
+    """Convert longitude from -180-180 to 0-360"""
     ds[lon_name].values = np.where(
         ds[lon_name].values < 0, 360 + ds[lon_name].values, ds[lon_name].values
-        )
+    )
 
     # sort the dataset by the new lon values
     ds = ds.sel(**{lon_name: np.sort(ds[lon_name].values)})
@@ -31,10 +31,9 @@ def convert_lons_mono(ds, lon_name='longitude'):
     return ds
 
 
-def convert_lons_split(ds, lon_name='longitude'):
-    """ Convert longitude from 0-360 to -180-180 """
-    ds[lon_name].values = xr.where(
-        ds[lon_name] > 180, ds[lon_name] - 360, ds[lon_name])
+def convert_lons_split(ds, lon_name="longitude"):
+    """Convert longitude from 0-360 to -180-180"""
+    ds[lon_name].values = xr.where(ds[lon_name] > 180, ds[lon_name] - 360, ds[lon_name])
 
     # sort the dataset by the new lon values
     ds = ds.sel(**{lon_name: np.sort(ds[lon_name].values)})
@@ -43,54 +42,52 @@ def convert_lons_split(ds, lon_name='longitude'):
 
 
 def rename_coords_to_lon_and_lat(ds):
-    """ Rename Dataset spatial coord names to:
-        lat, lon
+    """Rename Dataset spatial coord names to:
+    lat, lon
     """
-    if 'latitude' in ds.coords:
-        ds = ds.rename({'latitude': 'lat'})
-    if 'longitude' in ds.coords:
-        ds = ds.rename({'longitude': 'lon'})
-    elif 'long' in ds.coords:
-        ds = ds.rename({'long': 'lon'})
+    if "latitude" in ds.coords:
+        ds = ds.rename({"latitude": "lat"})
+    if "longitude" in ds.coords:
+        ds = ds.rename({"longitude": "lon"})
+    elif "long" in ds.coords:
+        ds = ds.rename({"long": "lon"})
 
-    if 'z' in ds.coords:
-        ds = ds.drop('z').squeeze()
+    if "z" in ds.coords:
+        ds = ds.drop("z").squeeze()
 
     return ds
 
 
 def rename_coords_to_longitude_and_latitude(ds):
-    """ Rename Dataset spatial coord names to:
-        latitude, longitude
+    """Rename Dataset spatial coord names to:
+    latitude, longitude
     """
-    if 'lat' in ds.coords:
-        ds = ds.rename({'lat': 'latitude'})
-    if 'lon' in ds.coords:
-        ds = ds.rename({'lon': 'longitude'})
-    elif 'long' in ds.coords:
-        ds = ds.rename({'long': 'longitude'})
+    if "lat" in ds.coords:
+        ds = ds.rename({"lat": "latitude"})
+    if "lon" in ds.coords:
+        ds = ds.rename({"lon": "longitude"})
+    elif "long" in ds.coords:
+        ds = ds.rename({"long": "longitude"})
 
-    if 'z' in ds.coords:
-        ds = ds.drop('z').squeeze()
+    if "z" in ds.coords:
+        ds = ds.drop("z").squeeze()
 
     return ds
 
 
 def remove_leap_days(ds):
-    ds = ds.loc[{
-        'time': ~((ds['time.month'] == 2) & (ds['time.day'] == 29))}]
+    ds = ds.loc[{"time": ~((ds["time.month"] == 2) & (ds["time.day"] == 29))}]
 
     return ds
 
 
 def season_boundaries(growing_days):
-    """ Returns the sorted start and end date of growing season
-    """
+    """Returns the sorted start and end date of growing season"""
 
     # the longitude values of the data is off, we need to scale it
     growing_days.longitude.values = growing_days.longitude.values - 180
     # we then sort by longitude
-    growing_days = growing_days.sortby('longitude')
+    growing_days = growing_days.sortby("longitude")
 
     # construct the ds
     gdd_sorted = xr.DataArray(
@@ -98,18 +95,18 @@ def season_boundaries(growing_days):
         # we use np.sort but construct the matrix from a xarray dataArray
         # we use transpose to track the axis we want to sort along
         np.sort(
-            growing_days.variable.transpose(
-                'latitude', 'longitude', 'z').values, axis=2),
-        dims=('latitude', 'longitude', 'sort'),
+            growing_days.variable.transpose("latitude", "longitude", "z").values, axis=2
+        ),
+        dims=("latitude", "longitude", "sort"),
         coords={
-                'latitude': growing_days.latitude,
-                'longitude': growing_days.longitude,
-                'sort': pd.Index(['min', 'max'])
-                }
-        )
+            "latitude": growing_days.latitude,
+            "longitude": growing_days.longitude,
+            "sort": pd.Index(["min", "max"]),
+        },
+    )
 
     # we can then select an axis in the sorted dataarray as min
-    min_day, max_day = gdd_sorted.sel(sort='min'), gdd_sorted.sel(sort='max')
+    min_day, max_day = gdd_sorted.sel(sort="min"), gdd_sorted.sel(sort="max")
 
     return min_day, max_day
 
@@ -140,22 +137,18 @@ def get_daily_growing_season_mask(lat, lon, time, growing_days_path):
 
     data = np.ones((lat.shape[0], lon.shape[0], time.shape[0]))
     # create an array of ones in the shape of the data
-    ones = xr.DataArray(
-                    data, coords=[lat, lon, time], dims=['lat', 'lon', 'time'])
+    ones = xr.DataArray(data, coords=[lat, lon, time], dims=["lat", "lon", "time"])
 
     # mask the array around the within calendar year start and end times
     # of growing season
-    mask = (
-        (ones['time.dayofyear'] >= min_day) &
-        (ones['time.dayofyear'] <= max_day))
+    mask = (ones["time.dayofyear"] >= min_day) & (ones["time.dayofyear"] <= max_day)
 
     # apply this mask and
     finalmask = (
-        mask.where(
-            growing_days.variable.sel(z=2) >=
-            growing_days.variable.sel(z=1)).fillna(1-mask).where(
-                ~growing_days.variable.sel(z=1, drop=True).isnull()
-                ).rename({'latitude': 'lat', 'longitude': 'lon'})
-            )
+        mask.where(growing_days.variable.sel(z=2) >= growing_days.variable.sel(z=1))
+        .fillna(1 - mask)
+        .where(~growing_days.variable.sel(z=1, drop=True).isnull())
+        .rename({"latitude": "lat", "longitude": "lon"})
+    )
 
     return finalmask

--- a/climate_toolbox/utils/utils.py
+++ b/climate_toolbox/utils/utils.py
@@ -4,6 +4,7 @@ Handy functions for standardizing the format of climate data
 
 import xarray as xr
 import numpy as np
+import pandas as pd
 
 
 def convert_kelvin_to_celsius(df, temp_name):

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,11 @@ universal = 1
 
 [flake8]
 exclude = docs
+ignore = E203,E266,E402,E501,W503,F401,C901
+max-line-length = 100
+max-complexity = 18
+select = B,C,E,F,W,T4,B9
+
 
 [aliases]
 test = pytest

--- a/tests/test_climate_toolbox.py
+++ b/tests/test_climate_toolbox.py
@@ -5,13 +5,20 @@
 
 import pytest
 
-from climate_toolbox.utils.utils import *
+from climate_toolbox.utils.utils import (
+    rename_coords_to_lon_and_lat,
+    rename_coords_to_longitude_and_latitude,
+    convert_lons_mono,
+    convert_lons_split,
+    remove_leap_days,
+    convert_kelvin_to_celsius,
+)
 from climate_toolbox.aggregations.aggregations import (
     _reindex_spatial_data_to_regions,
     _aggregate_reindexed_data_to_regions,
 )
 from climate_toolbox.transformations.transformations import snyder_edd, snyder_gdd
-from climate_toolbox.io import *
+from climate_toolbox.io import standardize_climate_data
 
 import numpy as np
 import pandas as pd

--- a/tests/test_climate_toolbox.py
+++ b/tests/test_climate_toolbox.py
@@ -6,8 +6,10 @@
 import pytest
 
 from climate_toolbox.utils.utils import *
-from climate_toolbox.aggregations.aggregations import \
-    _reindex_spatial_data_to_regions, _aggregate_reindexed_data_to_regions
+from climate_toolbox.aggregations.aggregations import (
+    _reindex_spatial_data_to_regions,
+    _aggregate_reindexed_data_to_regions,
+)
 from climate_toolbox.transformations.transformations import snyder_edd, snyder_gdd
 from climate_toolbox.io import *
 
@@ -20,22 +22,23 @@ import xarray as xr
 
 # create pytest resource to be used across tests
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def lat():
 
     return np.arange(-89.875, 90, 2)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def lon():
 
     return np.arange(0.125, 360.0, 2)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def time():
 
-    return pd.date_range(start=pd.datetime(2000, 1, 1), periods=10, freq='D')
+    return pd.date_range(start=pd.datetime(2000, 1, 1), periods=10, freq="D")
 
 
 @pytest.fixture
@@ -44,12 +47,12 @@ def clim_data(lat, lon, time):
     Generate fake climate data to do tests on
     """
     np.random.seed(42)
-    temp = np.random.rand(len(lat), len(lon), len(time))*100
+    temp = np.random.rand(len(lat), len(lon), len(time)) * 100
 
-    ds = xr.Dataset({'temperature': (['lat', 'lon', 'time'],  temp)},
-                    coords={'lon': lon,
-                            'lat': lat,
-                            'time': time})
+    ds = xr.Dataset(
+        {"temperature": (["lat", "lon", "time"], temp)},
+        coords={"lon": lon, "lat": lat, "time": time},
+    )
 
     return ds
 
@@ -64,11 +67,11 @@ def make_holes(clim_data, lat):
 
     N = len(lat) - 1
 
-    tmp = clim_data['temperature'].values
+    tmp = clim_data["temperature"].values
     array = np.random.randint(0, N, 1)
     tmp[array] = np.nan
 
-    clim_data['temperature'].values = tmp
+    clim_data["temperature"].values = tmp
 
     return clim_data
 
@@ -79,20 +82,19 @@ def weights(lat, lon):
     df = pd.DataFrame()
     lats = np.random.choice(lat, 100)
     lons = np.random.choice(lon, 100)
-    df['lat'] = lats
-    df['lon'] = lons
+    df["lat"] = lats
+    df["lon"] = lons
 
-    df['areawt'] = np.random.random(len(df['lon']))
-    tmp = np.random.random(len(df['lon']))
+    df["areawt"] = np.random.random(len(df["lon"]))
+    tmp = np.random.random(len(df["lon"]))
     tmp[::5] = np.nan
-    df['popwt'] = tmp
-    df['hierid'] = np.random.choice(np.arange(1, 25), len(lats))
+    df["popwt"] = tmp
+    df["hierid"] = np.random.choice(np.arange(1, 25), len(lats))
 
-    mapping = {
-        h: np.random.choice(np.arange(1, 5)) for h in df['hierid'].values}
+    mapping = {h: np.random.choice(np.arange(1, 5)) for h in df["hierid"].values}
 
-    df['ISO'] = [mapping[i] for i in df['hierid']]
-    df.index.names = ['reshape_index']
+    df["ISO"] = [mapping[i] for i in df["hierid"]]
+    df.index.names = ["reshape_index"]
 
     return df
 
@@ -103,79 +105,78 @@ def test_reindex_spatial_weights(clim_data, weights):
 
     ds = _reindex_spatial_data_to_regions(clim_data, weights)
 
-    assert ds.temperature.shape == (len(ds['lon']), len(ds['time']))
-    assert 'reshape_index' in ds.dims
+    assert ds.temperature.shape == (len(ds["lon"]), len(ds["time"]))
+    assert "reshape_index" in ds.dims
 
 
 def test_weighting(clim_data, weights):
 
-    assert np.isnan(weights['popwt'].values).any()
+    assert np.isnan(weights["popwt"].values).any()
     ds = _reindex_spatial_data_to_regions(clim_data, weights)
     assert not ds.temperature.isnull().any()
 
     wtd = _aggregate_reindexed_data_to_regions(
-        ds, 'temperature', 'popwt', 'ISO', weights)
+        ds, "temperature", "popwt", "ISO", weights
+    )
 
     assert not wtd.temperature.isnull().any()
 
     wtd = _aggregate_reindexed_data_to_regions(
-        ds, 'temperature', 'areawt', 'ISO', weights)
+        ds, "temperature", "areawt", "ISO", weights
+    )
 
     assert not wtd.temperature.isnull().any()
 
 
 def test_rename_coords_to_lon_and_lat():
-    ds = xr.Dataset(
-        coords={'z': [1.20, 2.58], 'long': [156.6, 38.48]})
+    ds = xr.Dataset(coords={"z": [1.20, 2.58], "long": [156.6, 38.48]})
 
     ds = rename_coords_to_lon_and_lat(ds)
     coords = ds.coords
 
-    assert 'z' not in coords
+    assert "z" not in coords
     assert coords.z is None
-    assert 'lon' in coords and 'long' not in coords
+    assert "lon" in coords and "long" not in coords
 
 
 def test_rename_coords_to_lon_and_lat():
-    ds = xr.Dataset(
-        coords={'latitude': [71.32, 72.58], 'longitude': [156.6, 38.48]})
+    ds = xr.Dataset(coords={"latitude": [71.32, 72.58], "longitude": [156.6, 38.48]})
 
     ds = rename_coords_to_lon_and_lat(ds)
     coords = ds.coords
 
-    assert 'lat' in coords and 'latitude' not in coords
-    assert 'lon' in coords and 'longitude' not in coords
+    assert "lat" in coords and "latitude" not in coords
+    assert "lon" in coords and "longitude" not in coords
 
 
 def test_rename_coords_to_longitude_and_latitude():
-    ds = xr.Dataset(
-        coords={'lat': [71.32, 72.58], 'lon': [156.6, 38.48]})
+    ds = xr.Dataset(coords={"lat": [71.32, 72.58], "lon": [156.6, 38.48]})
     ds = rename_coords_to_longitude_and_latitude(ds)
     coords = ds.coords
 
-    assert 'latitude' in coords and 'lat' not in coords
-    assert 'longitude' in coords and 'lon' not in coords
+    assert "latitude" in coords and "lat" not in coords
+    assert "longitude" in coords and "lon" not in coords
 
 
 def test_rename_coords_to_longitude_and_latitude_with_clim_data(clim_data):
     ds = rename_coords_to_longitude_and_latitude(clim_data)
     coords = ds.coords
 
-    assert 'latitude' in coords and 'lat' not in coords
-    assert 'longitude' in coords and 'lon' not in coords
+    assert "latitude" in coords and "lat" not in coords
+    assert "longitude" in coords and "lon" not in coords
 
 
 def test_convert_lons_mono():
-    ds = xr.Dataset(coords={'lon': [-156.6, -38.48]})
+    ds = xr.Dataset(coords={"lon": [-156.6, -38.48]})
     expected = np.array([203.4, 321.52])
 
-    ds = convert_lons_mono(ds, lon_name='lon')
+    ds = convert_lons_mono(ds, lon_name="lon")
 
     np.testing.assert_array_equal(ds.lon.values, expected)
 
 
 def test_convert_lons_split():
-    ds = xr.Dataset(coords={'longitude': [300, 320]})
+    ds = xr.Dataset(coords={"longitude": [300, 320]})
     expected = np.array([-60, -40])
 
     ds = convert_lons_split(ds)
@@ -186,27 +187,30 @@ def test_convert_lons_split():
 def test_remove_leap_days():
     da = xr.DataArray(
         np.random.rand(4, 3),
-        [('time', pd.date_range('2000-02-27', periods=4)),
-         ('space', ['IA', 'IL', 'IN'])])
-    leap_day = np.datetime64('2000-02-29')
+        [
+            ("time", pd.date_range("2000-02-27", periods=4)),
+            ("space", ["IA", "IL", "IN"]),
+        ],
+    )
+    leap_day = np.datetime64("2000-02-29")
 
     da = remove_leap_days(da)
 
-    assert leap_day not in da.coords['time'].values
+    assert leap_day not in da.coords["time"].values
 
 
 def test_remove_leap_days_with_clim_data(clim_data):
-    leap_day = np.datetime64('2000-02-29')
+    leap_day = np.datetime64("2000-02-29")
 
     da = remove_leap_days(clim_data)
 
-    assert leap_day not in da.coords['time'].values
+    assert leap_day not in da.coords["time"].values
 
 
 def test_convert_kelvin_to_celsius(clim_data):
-    ds = convert_kelvin_to_celsius(clim_data, 'temperature')
+    ds = convert_kelvin_to_celsius(clim_data, "temperature")
 
-    assert 'C' in ds.data_vars['temperature'].units
+    assert "C" in ds.data_vars["temperature"].units
 
 
 def test_standardize_climate_data(clim_data):
@@ -214,47 +218,55 @@ def test_standardize_climate_data(clim_data):
 
     coordinates = ds.coords
 
-    assert 'lat' in coordinates and 'latitude' not in coordinates
-    assert 'lon' in coordinates and 'longitude' not in coordinates
-    
-    
+    assert "lat" in coordinates and "latitude" not in coordinates
+    assert "lon" in coordinates and "longitude" not in coordinates
+
+
 def test_snyder_edd():
     ds_tasmax = xr.Dataset(
-        data_vars={'tmax': (
-            '(latitude, longitude)', [280.4963, 280.7887], {'units': 'K'})},
-        coords={'latitude': [-33.625, -33.375], 'longitude': [286.125, 286.375]})
+        data_vars={
+            "tmax": ("(latitude, longitude)", [280.4963, 280.7887], {"units": "K"})
+        },
+        coords={"latitude": [-33.625, -33.375], "longitude": [286.125, 286.375]},
+    )
 
     ds_tasmin = xr.Dataset(
-        data_vars={'tmin': (
-            '(latitude, longitude)', [278.902, 278.23163], {'units': 'K'})},
-        coords={'latitude': [-33.625, -33.375], 'longitude': [286.125, 286.375]})
+        data_vars={
+            "tmin": ("(latitude, longitude)", [278.902, 278.23163], {"units": "K"})
+        },
+        coords={"latitude": [-33.625, -33.375], "longitude": [286.125, 286.375]},
+    )
 
     threshold = 8
 
-    res = snyder_edd(
-                ds_tasmin.tmin,
-                ds_tasmax.tmax,
-                threshold=273.15 + threshold)
-    
-    assert res.units == 'degreedays_281.15K'
+    res = snyder_edd(ds_tasmin.tmin, ds_tasmax.tmax, threshold=273.15 + threshold)
+
+    assert res.units == "degreedays_281.15K"
     assert res.sum().item(0) == 0.0
 
-    
+
 def test_snyder_gdd():
     ds_tasmax = xr.Dataset(
-        data_vars={'tmax': ('(latitude, longitude)', [280.4963, 280.7887], {'units': 'K'})},
-        coords={'latitude': [-33.625, -33.375], 'longitude': [286.125, 286.375]})
+        data_vars={
+            "tmax": ("(latitude, longitude)", [280.4963, 280.7887], {"units": "K"})
+        },
+        coords={"latitude": [-33.625, -33.375], "longitude": [286.125, 286.375]},
+    )
 
     ds_tasmin = xr.Dataset(
-        data_vars={'tmin': ('(latitude, longitude)', [278.902, 278.23163], {'units': 'K'})},
-        coords={'latitude': [-33.625, -33.375], 'longitude': [286.125, 286.375]})
-    
+        data_vars={
+            "tmin": ("(latitude, longitude)", [278.902, 278.23163], {"units": "K"})
+        },
+        coords={"latitude": [-33.625, -33.375], "longitude": [286.125, 286.375]},
+    )
+
     res = snyder_gdd(
-            ds_tasmin.tmin,
-            ds_tasmax.tmax,
-            threshold_low=273.15 + 1,
-            threshold_high=273.15 + 8)
-    
-    assert not res.units == 'degreedays_281.15K'
-    assert res.units == 'degreedays_274.15-281.15K'
+        ds_tasmin.tmin,
+        ds_tasmax.tmax,
+        threshold_low=273.15 + 1,
+        threshold_high=273.15 + 8,
+    )
+
+    assert not res.units == "degreedays_281.15K"
+    assert res.units == "degreedays_274.15-281.15K"
     assert res.sum().item(0) == pytest.approx(11, 0.1)

--- a/tests/test_climate_toolbox.py
+++ b/tests/test_climate_toolbox.py
@@ -146,7 +146,7 @@ def test_rename_coords_to_lon_and_lat():
     assert "lon" in coords and "long" not in coords
 
 
-def test_rename_coords_to_lon_and_lat():
+def test_rename_coords_to_lon_and_lat2():
     ds = xr.Dataset(coords={"latitude": [71.32, 72.58], "longitude": [156.6, 38.48]})
 
     ds = rename_coords_to_lon_and_lat(ds)


### PR DESCRIPTION
We got automated tests up and running in CI with PR #35. Once it started to run `flake8` immediately flagged climate_toolbox code for a number of reasons. This PR resolves those issues.

* Add a basic `flake8` configuration to `setup.cfg` so we focus on big and immediate problems.
* I autoformatted all package and test code with `black`. This isn't required right now, but it's the fastest way to get minor formatting fixes so the code passes the `flake8` check in CI.
* Fix "undefined" error in `climate_toolbox/utils/utils.py`.
* Fix several ambiguous star imports in `climate_toolbox/io/io.py` and `tests/test_climate_toolbox.py`.
* Fix an issue with overwritten test functions in `tests/test_climate_toolbox.py`.
* Dropped unused variable in `load_bcsd()` from `climate_toolbox/io/io.py`.

With these changes, `flake8` passes the code on my local machine.