### PR TITLE
Fix pytest failing in CI with ModuleNotFoundErrors

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,14 +1,13 @@
 bumpversion==0.5.3
 wheel==0.29.0
 flake8
-tox==2.7.0
+tox==3.25.1
 coverage==4.4.1
 Sphinx==1.6.3
 PyYAML>=4.2b1
-pytest
+pytest==7.1.2
 pytest-runner==2.11.1
 pytest-cov
-py==1.4.34
 numpy
 pandas
 scipy


### PR DESCRIPTION
Recent pytest runs in CI checks have been failing with `ModuleNotFoundErrors` ([e.g.](https://github.com/ClimateImpactLab/climate_toolbox/runs/7084253305)). This PR fixes these by wiggling CI environment dependencies.

We have lots of old, busted version pins. This wiggles the pins juuust enough to get CI running without dramatic changes otherwise.